### PR TITLE
idiomatic naming: changing `amount_*s` to `*_count`

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -88,7 +88,7 @@ pub fn parse(filename: &str) -> Result<PDB, String> {
                     }
                 }
                 LexItem::Model(number) => {
-                    if current_model.amount_atoms() > 0 {
+                    if current_model.atom_count() > 0 {
                         pdb.add_model(current_model)
                     }
 

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -55,13 +55,13 @@ impl Chain {
     }
 
     /// Get the amount of Residues making up this Chain
-    pub fn amount_residues(&self) -> usize {
+    pub fn residue_count(&self) -> usize {
         self.residues.len()
     }
 
     /// Get the amount of Atoms making up this Chain
-    pub fn amount_atoms(&self) -> usize {
-        self.residues().fold(0, |sum, res| res.amount_atoms() + sum)
+    pub fn atom_count(&self) -> usize {
+        self.residues().fold(0, |sum, res| res.atom_count() + sum)
     }
 
     /// Get a specific Residue from list of Residues making up this Chain.

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -48,42 +48,42 @@ impl Model {
 
     /// Get the amount of Chains making up this Model.
     /// This disregards all Hetero Chains.
-    pub fn amount_chains(&self) -> usize {
+    pub fn chain_count(&self) -> usize {
         self.chains.len()
     }
 
     /// Get the amount of Residues making up this Model.
     /// This disregards all Hetero Residues.
-    pub fn amount_residues(&self) -> usize {
+    pub fn residue_count(&self) -> usize {
         self.chains()
-            .fold(0, |sum, chain| chain.amount_residues() + sum)
+            .fold(0, |sum, chain| chain.residue_count() + sum)
     }
 
     /// Get the amount of Atoms making up this Model.
     /// This disregards all Hetero Atoms.
-    pub fn amount_atoms(&self) -> usize {
+    pub fn atom_count(&self) -> usize {
         self.chains()
-            .fold(0, |sum, chain| chain.amount_atoms() + sum)
+            .fold(0, |sum, chain| chain.atom_count() + sum)
     }
 
     /// Get the amount of Chains making up this Model.
     /// This includes all Hetero Chains.
-    pub fn total_amount_chains(&self) -> usize {
+    pub fn total_chain_count(&self) -> usize {
         self.chains.len() + self.hetero_chains.len()
     }
 
     /// Get the amount of Residues making up this Model.
     /// This includes all Hetero Residues.
-    pub fn total_amount_residues(&self) -> usize {
+    pub fn total_residue_count(&self) -> usize {
         self.all_chains()
-            .fold(0, |sum, chain| chain.amount_residues() + sum)
+            .fold(0, |sum, chain| chain.residue_count() + sum)
     }
 
     /// Get the amount of Atoms making up this Model.
     /// This includes all Hetero Atoms.
-    pub fn total_amount_atoms(&self) -> usize {
+    pub fn total_atom_count(&self) -> usize {
         self.all_chains()
-            .fold(0, |sum, chain| chain.amount_atoms() + sum)
+            .fold(0, |sum, chain| chain.atom_count() + sum)
     }
 
     /// Get a specific Chain from list of Chains making up this Model.

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -239,15 +239,15 @@ impl PDB {
     }
 
     /// Get the amount of Models making up this PDB
-    pub fn amount_models(&self) -> usize {
+    pub fn model_count(&self) -> usize {
         self.models.len()
     }
 
     /// Get the amount of Chains making up this PDB.
     /// Disregarding Hetero Chains.
-    pub fn amount_chains(&self) -> usize {
+    pub fn chain_count(&self) -> usize {
         if self.models.len() > 0 {
-            self.models[0].amount_chains()
+            self.models[0].chain_count()
         } else {
             0
         }
@@ -255,9 +255,9 @@ impl PDB {
 
     /// Get the amount of Residues making up this PDB.
     /// Disregarding Hetero Residues.
-    pub fn amount_residues(&self) -> usize {
+    pub fn residue_count(&self) -> usize {
         if self.models.len() > 0 {
-            self.models[0].amount_residues()
+            self.models[0].residue_count()
         } else {
             0
         }
@@ -265,9 +265,9 @@ impl PDB {
 
     /// Get the amount of Atoms making up this PDB.
     /// Disregarding Hetero Atoms.
-    pub fn amount_atoms(&self) -> usize {
+    pub fn atom_count(&self) -> usize {
         if self.models.len() > 0 {
-            self.models[0].amount_atoms()
+            self.models[0].atom_count()
         } else {
             0
         }
@@ -275,20 +275,20 @@ impl PDB {
 
     /// Get the amount of Chains making up this PDB.
     /// Including Hetero Chains.
-    pub fn total_amount_chains(&self) -> usize {
-        self.models.len() * self.amount_chains()
+    pub fn total_chain_count(&self) -> usize {
+        self.models.len() * self.chain_count()
     }
 
     /// Get the amount of Residues making up this PDB.
     /// Including Hetero Residues.
-    pub fn total_amount_residues(&self) -> usize {
-        self.models.len() * self.amount_residues()
+    pub fn total_residue_count(&self) -> usize {
+        self.models.len() * self.residue_count()
     }
 
     /// Get the amount of Atoms making up this PDB.
     /// Including Hetero Atoms.
-    pub fn total_amount_atoms(&self) -> usize {
-        self.models.len() * self.amount_atoms()
+    pub fn total_atom_count(&self) -> usize {
+        self.models.len() * self.atom_count()
     }
 
     /// Get a specific Model from list of Models making up this PDB.

--- a/src/structs/residue.rs
+++ b/src/structs/residue.rs
@@ -107,7 +107,7 @@ impl Residue {
     }
 
     /// The amount of atoms making up this Residue
-    pub fn amount_atoms(&self) -> usize {
+    pub fn atom_count(&self) -> usize {
         self.atoms.len()
     }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -12,7 +12,7 @@ use crate::structs::*;
 pub fn validate(pdb: &PDB) -> bool {
     // Print warnings/errors and return a bool for success
     let mut output = true;
-    if pdb.amount_models() > 1 {
+    if pdb.model_count() > 1 {
         output = output && validate_models(pdb)
     }
     if pdb.has_scale() {
@@ -30,18 +30,18 @@ pub fn validate(pdb: &PDB) -> bool {
 /// Validate the models by enforcing that all models should contain the same atoms (with possibly different data).
 /// It checks this by matching all atoms (not hetatoms) for each model to see if they correspond (`Atom::correspond`).
 fn validate_models(pdb: &PDB) -> bool {
-    let total_atoms = pdb.model(0).unwrap().amount_atoms();
+    let total_atoms = pdb.model(0).unwrap().atom_count();
     for model in pdb.models().skip(1) {
-        if model.amount_atoms() != total_atoms {
+        if model.atom_count() != total_atoms {
             println!(
                 "{} does not have the same amount of atoms as the first model ({} (this model) vs {} (first)).",
                 model,
-                model.amount_atoms(),
+                model.atom_count(),
                 total_atoms
             );
             return false;
         }
-        for index in 0..model.amount_atoms() {
+        for index in 0..model.atom_count() {
             let current_atom = model.atom(index).unwrap();
             let standard_atom = pdb.model(0).unwrap().atom(index).unwrap();
             if !standard_atom.corresponds(current_atom) {

--- a/tests/read_write_pdbs.rs
+++ b/tests/read_write_pdbs.rs
@@ -38,10 +38,10 @@ fn do_someting(file: &str, output: &str) {
 
     println!(
         "Found {} atoms, in {} residues, in {} chains, in {} models it all took {} ms",
-        pdb.total_amount_atoms(),
-        pdb.total_amount_residues(),
-        pdb.total_amount_chains(),
-        pdb.amount_models(),
+        pdb.total_atom_count(),
+        pdb.total_residue_count(),
+        pdb.total_chain_count(),
+        pdb.model_count(),
         time.as_millis()
     );
 


### PR DESCRIPTION
It's idiomatic to name the method that count the number of items in a collection `<item>_count`, as exemplified in [std](https://doc.rust-lang.org/std/?search=count) and some [non-std crates](https://docs.rs/petgraph/0.5.1/petgraph/?search=count)

Also, "amount" is used with uncountables in English, "count" or "number" are used with countables.