### PR TITLE
refactor

### DIFF
--- a/src/structs/atom.rs
+++ b/src/structs/atom.rs
@@ -33,7 +33,7 @@ pub struct Atom {
 impl Atom {
     /// Create a new Atom
     pub fn new(
-        residue: Option<&mut Residue>,
+        residue: Option<*mut Residue>,
         serial_number: usize,
         atom_name: [char; 4],
         x: f64,
@@ -44,7 +44,7 @@ impl Atom {
         element: [char; 2],
         charge: [char; 2],
     ) -> Option<Atom> {
-        let mut atom = Atom {
+        let atom = Atom {
             serial_number,
             name: atom_name,
             x,
@@ -54,13 +54,9 @@ impl Atom {
             b_factor,
             element,
             charge,
-            residue: None,
+            residue,
             atf: None,
         };
-
-        if let Some(reference) = residue {
-            atom.residue = Some(reference);
-        }
 
         if !check_char4(atom_name) || !check_char2(element) || !check_char2(charge) {
             None

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -22,21 +22,15 @@ impl Chain {
     ///
     /// ## Fails
     /// It fails if the identifier is an invalid character.
-    pub fn new(id: char, model: Option<&mut Model>) -> Option<Chain> {
+    pub fn new(id: char, model: Option<*mut Model>) -> Option<Chain> {
         if !check_char(id) {
             return None;
         }
-        let mut c = Chain {
+        Some(Chain {
             id: id,
             residues: Vec::new(),
-            model: None,
-        };
-
-        if let Some(m) = model {
-            c.model = Some(m);
-        }
-
-        Some(c)
+            model,
+        })
     }
 
     /// The ID of the Chain
@@ -244,9 +238,13 @@ impl Chain {
         }
     }
 
-    pub fn remove_residues_by<F>(&mut self, predicate: F) where F: Fn(&Residue) -> bool {
+    pub fn remove_residues_by<F>(&mut self, predicate: F)
+    where
+        F: Fn(&Residue) -> bool,
+    {
         let residues = std::mem::replace(&mut self.residues, Vec::default());
-        self.residues.extend(residues.into_iter().filter(|residue|!predicate(residue)));
+        self.residues
+            .extend(residues.into_iter().filter(|residue| !predicate(residue)));
     }
 
     /// Remove the Residue specified.

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -21,19 +21,13 @@ impl Model {
     /// ## Arguments
     /// * `serial_number` - the serial number
     /// * `pdb` - if available the parent of the Model
-    pub fn new(serial_number: usize, pdb: Option<&mut PDB>) -> Model {
-        let mut model = Model {
+    pub fn new(serial_number: usize, pdb: Option<*mut PDB>) -> Model {
+        Model {
             serial_number: serial_number,
             chains: Vec::new(),
             hetero_chains: Vec::new(),
-            pdb: None,
-        };
-
-        if let Some(p) = pdb {
-            model.pdb = Some(p);
+            pdb,
         }
-
-        model
     }
 
     /// The serial number of this Model
@@ -62,8 +56,7 @@ impl Model {
     /// Get the amount of Atoms making up this Model.
     /// This disregards all Hetero Atoms.
     pub fn atom_count(&self) -> usize {
-        self.chains()
-            .fold(0, |sum, chain| chain.atom_count() + sum)
+        self.chains().fold(0, |sum, chain| chain.atom_count() + sum)
     }
 
     /// Get the amount of Chains making up this Model.

--- a/src/structs/residue.rs
+++ b/src/structs/residue.rs
@@ -32,7 +32,7 @@ impl Residue {
         number: usize,
         name: [char; 3],
         atom: Option<Atom>,
-        chain: Option<&mut Chain>,
+        chain: Option<*mut Chain>,
     ) -> Option<Residue> {
         if !check_char3(name) {
             return None;
@@ -288,8 +288,7 @@ impl Residue {
     /// Remove this Residue from its parent Chain
     pub fn remove(&mut self) {
         let i = self.serial_number();
-        self.chain_mut()
-            .remove_residue_serial_number(i);
+        self.chain_mut().remove_residue_serial_number(i);
     }
 
     /// Apply a transformation to the position of all atoms making up this Residue, the new position is immediately set.


### PR DESCRIPTION
Either `&mut T` or `*mut T` can be automatically coerced to `*mut T` when passed as a function argument, for example:

```rust
fn main() {
    let mut i = 0;
    print_a_option_mut_i32(Some(&mut i));
}

fn print_a_option_mut_i32(p: Option<*mut i32>) {
    println!("{:?}", unsafe { *p.unwrap() });
}
```

And because it's a raw pointer anyways, it is good to be explicit