### PR TITLE
a new atom should not contain a pointer to the parent

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -61,7 +61,7 @@ pub fn parse(filename: &str) -> Result<PDB, String> {
             match result {
                 LexItem::Remark(num, text) => pdb.add_remark(num, text.to_string()),
                 LexItem::Atom(hetero, s, n, _, r, c, rs, _, x, y, z, o, b, _, e, ch) => {
-                    let atom = Atom::new(None, s, n, x, y, z, o, b, e, ch)
+                    let atom = Atom::new(s, n, x, y, z, o, b, e, ch)
                         .expect("Invalid characters in atom creation");
 
                     if hetero {

--- a/src/structs/atom.rs
+++ b/src/structs/atom.rs
@@ -33,7 +33,6 @@ pub struct Atom {
 impl Atom {
     /// Create a new Atom
     pub fn new(
-        residue: Option<*mut Residue>,
         serial_number: usize,
         atom_name: [char; 4],
         x: f64,
@@ -54,7 +53,7 @@ impl Atom {
             b_factor,
             element,
             charge,
-            residue,
+            residue: None,
             atf: None,
         };
 
@@ -438,7 +437,6 @@ impl fmt::Display for Atom {
 impl Clone for Atom {
     fn clone(&self) -> Self {
         let mut atom = Atom::new(
-            None,
             self.serial_number,
             self.name,
             self.x,


### PR DESCRIPTION
From my experience with doublely linked trees/linked lists, a new node should not contain a pointer to a parent. This pointer should be added explicitly from the parent's "add child" method. (e.g. https://doc.rust-lang.org/src/alloc/collections/linked_list.rs.html#120 )

In this case, for example, someone might assume that an atom can be added to a chain by providing a `Some(pointer)` as the first argument. However, this fails, because in the `new` method the new atom is not pushed to the parent's Vec of atoms (and indeed this is impossible to implement in the `new` method—you can't push an `Atom` before it's produced, and thus a new Atom must have `None` in the `chain` field).